### PR TITLE
nvim-tree is not lazy loaded

### DIFF
--- a/lua/modules/global/init.lua
+++ b/lua/modules/global/init.lua
@@ -42,6 +42,7 @@ modules["lukas-reineke/indent-blankline.nvim"] = {
 
 modules["kyazdani42/nvim-tree.lua"] = {
     cmd = "NvimTreeToggle",
+    opt = true,
     config = ui_config.tree,
     requires = "kyazdani42/nvim-web-devicons"
 }


### PR DESCRIPTION
New to Neovim and Lua, but lazyloading nvim-tree caused `NvimTreeToggle` to not be defined.

Setting `opt = true` in its Packer config fixed the issue.