### PR TITLE
feat(lsp preview): correct preview from actual goto

### DIFF
--- a/lua/configs/base/keymaps.lua
+++ b/lua/configs/base/keymaps.lua
@@ -46,16 +46,20 @@ keymaps["normal"] = {
     { "<A-[>", ":GitSignsPrevHunk<CR>" }, -- Git signs prev hunk
     { "<A-;>", ":GitSignsPreviewHunk<CR>" }, -- Git signs preview hunk
     { "<A-s>", ":Spectre<CR>" }, -- Replace in multiple files
+    { "gd", ":LspDefinition<CR>" }, -- Lsp definition
+    { "gt", ":LspTypeDefinition<CR>" }, -- Lsp type definition
+    { "gR", ":LspReferences<CR>" }, -- Lsp references
+    { "gpi", ":LspImplementation<CR>" }, -- Lsp implementation
     { "gw", ":WindowPicker<CR>" }, -- Window picker
     { "gr", ":LspRename<CR>" }, -- Lsp rename
     { "gf", ":LspFormatting<CR>" }, -- Lsp format code
     { "ga", ":LspCodeAction<CR>" }, -- Lsp code action
     { "gL", ":LspCodeLensRefresh<CR>" }, -- Lsp code lens refresh
     { "gl", ":LspCodeLensRun<CR>" }, -- Lsp code lens run
-    { "gpd", ":LspDefinition<CR>" }, -- Lsp definition
-    { "gpt", ":LspTypeDefinition<CR>" }, -- Lsp type definition
-    { "gpr", ":LspReferences<CR>" }, -- Lsp references
-    { "gpi", ":LspImplementation<CR>" }, -- Lsp implementation
+    { "gpd", ":LspPreviewDefinition<CR>" }, -- Lsp definition
+    { "gpt", ":LspPreviewTypeDefinition<CR>" }, -- Lsp type definition
+    { "gpr", ":LspPreviewReferences<CR>" }, -- Lsp references
+    { "gpi", ":LspPreviewImplementation<CR>" }, -- Lsp implementation
     { "gps", ":LspSignatureHelp<CR>" }, -- Lsp signsture help
     { "gpp", ":LspCloseAll<CR>" }, -- Lsp close all
     { "gh", ":Hover<CR>" }, -- Lsp hover

--- a/lua/modules/base/configs/languages/init.lua
+++ b/lua/modules/base/configs/languages/init.lua
@@ -113,15 +113,23 @@ function config.goto_preview()
         },
         border = { " ", " ", " ", " ", " ", " ", " ", " " }, -- Border characters of the floating window
     })
-    vim.api.nvim_create_user_command("LspDefinition", "lua require('goto-preview').goto_preview_definition()", {})
     vim.api.nvim_create_user_command(
-        "LspTypeDefinition",
+        "LspPreviewDefinition",
+        "lua require('goto-preview').goto_preview_definition()",
+        {}
+    )
+    vim.api.nvim_create_user_command(
+        "LspPreviewTypeDefinition",
         "lua require('goto-preview').goto_preview_type_definition()",
         {}
     )
-    vim.api.nvim_create_user_command("LspReferences", "lua require('goto-preview').goto_preview_references()", {})
     vim.api.nvim_create_user_command(
-        "LspImplementation",
+        "LspPreviewReferences",
+        "lua require('goto-preview').goto_preview_references()",
+        {}
+    )
+    vim.api.nvim_create_user_command(
+        "LspPreviewImplementation",
         "lua require('goto-preview').goto_preview_implementation()",
         {}
     )


### PR DESCRIPTION
This PR allows keybindings for:
 -  LspPreviewDefinition
 -  LspPreviewTypeDefinition
 -  LspPreviewReferences
 -  LspPreviewImplementation

and their goto counterparts:
 -  LspDefinition
 -  LspTypeDefinition
 -  LspReferences
 -  LspImplementation

since the later ones were overwritten by the implementation of the default ones.
This separation allows for a workflow that actually allows a developer to go to the file with the definition(et. al) and return to jump back with `<C-t>` and thus doesn't clutter the viewport with all kinds of popup windows.